### PR TITLE
- fix crash if import contains empty line

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,8 +9,7 @@ import (
 	"strings"
 )
 
-var in string
-var out string
+var in, out string
 
 func init() {
 	flag.StringVar(&in, "in", "", "-in path")
@@ -31,6 +30,9 @@ func main() {
 		n := file.Name()
 		if n == "vendor" {
 			fmt.Println("Warning: merging the vendor folder is not supported")
+			continue
+		}
+		if file.IsDir() {
 			continue
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMain__Simple(t *testing.T) {
+	// arrange
+	in = "./testdata/simple"
+	out = "./testdata/simple/result/merged.go"
+	// action
+	main()
+	// verify
+	result, _ := ioutil.ReadFile(out)
+	expected, _ := ioutil.ReadFile("./testdata/simple/result/merged_expected.go")
+	if !strings.EqualFold(string(expected), string(result)) {
+		t.Error("Merged result is not in expected form")
+	}
+	// cleanup
+	os.Remove(out)
+}
+
+func TestMain__Complex(t *testing.T) {
+	// arrange
+	in = "./testdata/complex"
+	out = "./testdata/complex/result/merged.go"
+	// action
+	main()
+	// verify
+	result, _ := ioutil.ReadFile(out)
+	expected, _ := ioutil.ReadFile("./testdata/complex/result/merged_expected.go")
+	if !strings.EqualFold(string(expected), string(result)) {
+		t.Error("Merged result is not in expected form")
+	}
+	// cleanup
+	os.Remove(out)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestMain__Simple(t *testing.T) {
+func TestMain_Simple(t *testing.T) {
 	// arrange
 	in = "./testdata/simple"
 	out = "./testdata/simple/result/merged.go"
@@ -23,7 +23,7 @@ func TestMain__Simple(t *testing.T) {
 	os.Remove(out)
 }
 
-func TestMain__Complex(t *testing.T) {
+func TestMain_Complex(t *testing.T) {
 	// arrange
 	in = "./testdata/complex"
 	out = "./testdata/complex/result/merged.go"

--- a/testdata/complex/result/merged_expected.go
+++ b/testdata/complex/result/merged_expected.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"github.com/golang/dep"
+)
+
+
+func printFoo() {
+	fmt.Println("Foo")
+}
+
+
+func logFoo() {
+	log.Println("Foo")
+
+	d := dep.Analyzer{}
+	fmt.Println(d)
+}

--- a/testdata/complex/test_a.go
+++ b/testdata/complex/test_a.go
@@ -1,0 +1,7 @@
+package foo
+
+import "fmt"
+
+func printFoo() {
+	fmt.Println("Foo")
+}

--- a/testdata/complex/test_b.go
+++ b/testdata/complex/test_b.go
@@ -1,0 +1,15 @@
+package foo
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/golang/dep"
+)
+
+func logFoo() {
+	log.Println("Foo")
+
+	d := dep.Analyzer{}
+	fmt.Println(d)
+}

--- a/testdata/simple/result/merged_expected.go
+++ b/testdata/simple/result/merged_expected.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"log"
+)
+
+
+func printFoo() {
+	fmt.Println("Foo")
+}
+
+
+func logFoo() {
+	log.Println("Foo")
+}

--- a/testdata/simple/test_a.go
+++ b/testdata/simple/test_a.go
@@ -1,0 +1,7 @@
+package foo
+
+import "fmt"
+
+func printFoo() {
+	fmt.Println("Foo")
+}

--- a/testdata/simple/test_b.go
+++ b/testdata/simple/test_b.go
@@ -1,0 +1,7 @@
+package foo
+
+import "log"
+
+func logFoo() {
+	log.Println("Foo")
+}


### PR DESCRIPTION
Moin,
für den Code of Kutulu wollte ich mal Go und deinen Merger ausprobieren.
Wenn im Import einer Datei eine Leerzeile ist, crasht er aber.

